### PR TITLE
refactor(hyprland): move media binds to allow lockscreen

### DIFF
--- a/modules/desktop/hyprland.nix
+++ b/modules/desktop/hyprland.nix
@@ -138,7 +138,7 @@ in {
 
             # Keybinds
             "$mod" = "SUPER";
-            bind = with pkgs;
+            bind =
               [
                 "$mod, return, exec, alacritty"
                 "$mod, W, killactive,"
@@ -148,19 +148,22 @@ in {
                 "$mod, RIGHT, movefocus, r"
                 "$mod, UP, movefocus, u"
                 "$mod, DOWN, movefocus, d"
-                ", XF86AudioRaiseVolume, exec, ${wireplumber}/bin/wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+"
-                ", XF86AudioLowerVolume, exec, ${wireplumber}/bin/wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-"
-                ", XF86AudioMute, exec, ${wireplumber}/bin/wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"
-                ", XF86AudioMicMute, exec, ${wireplumber}/bin/wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"
-                ", XF86AudioPlay, exec, ${playerctl}/bin/playerctl play-pause"
-                ", XF86AudioNext, exec, ${playerctl}/bin/playerctl next"
-                ", XF86AudioPrev, exec, ${playerctl}/bin/playerctl previous"
-                ", XF86audiostop, exec, ${playerctl}/bin/playerctl stop"
                 "SHIFT CTRL, space, exec, ${launcherScript}/bin/rofi-launcher drun"
                 "SHIFT CTRL, Q, exec, ${powermenuScript}/bin/rofi-powermenu"
               ]
               ++ workspaceBinds
               ++ monitorBinds;
+
+            bindl = with pkgs; [
+              ", XF86AudioRaiseVolume, exec, ${wireplumber}/bin/wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+"
+              ", XF86AudioLowerVolume, exec, ${wireplumber}/bin/wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-"
+              ", XF86AudioMute, exec, ${wireplumber}/bin/wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"
+              ", XF86AudioMicMute, exec, ${wireplumber}/bin/wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"
+              ", XF86AudioPlay, exec, ${playerctl}/bin/playerctl play-pause"
+              ", XF86AudioNext, exec, ${playerctl}/bin/playerctl next"
+              ", XF86AudioPrev, exec, ${playerctl}/bin/playerctl previous"
+              ", XF86audiostop, exec, ${playerctl}/bin/playerctl stop"
+            ];
             bindm = [
               "$mod, mouse:272, movewindow"
               "$mod, mouse:273, resizewindow"


### PR DESCRIPTION
This PR moves media control binds to `bindl` keyword allowing them to be used on the lockscreen.