### PR TITLE
refactor(nh): remove overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,13 +46,6 @@
     pkgs = import inputs.nixpkgs {
       inherit system;
       config.allowUnfree = true;
-
-      # TODO: Replace this dirty trick when nixos 24.05 releases
-      overlays = [
-        (final: prev: {
-          nh = unstable.nh;
-        })
-      ];
     };
 
     unstable = import inputs.nixpkgs-unstable {

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -24,7 +24,7 @@ with lib.my; {
           ./../configuration.nix
           ./../hosts/${name}/configuration.nix
 
-          # TODO: Replace this dirty trick when nixos 24.05 releases
+          # TODO: Remove this when nixos 24.05 releases
           "${unstable.path}/nixos/modules/programs/nh.nix"
 
           inputs.home-manager.nixosModules.home-manager

--- a/modules/desktop/apps/nh.nix
+++ b/modules/desktop/apps/nh.nix
@@ -1,6 +1,7 @@
-{...}: {
+{unstable, ...}: {
   programs.nh = {
     enable = true;
+    package = unstable.nh;
     clean = {
       enable = true;
       dates = "weekly";


### PR DESCRIPTION
This PR removes overlay for the `nh` package, by using the `unstable` version in the `programs.nh.package` config option.