### PR TITLE
feat: add secrets managment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .direnv/
+hosts/**/age.key

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,7 @@
+keys:
+  - &pc age1lxgv0sqxut6ekz9une8d4zzj4vkrlph58ewv5w6r6m0xxddw9dgs3j8q8r
+creation_rules:
+  - path_regex: hosts/pc/secrets.yaml$
+    key_groups:
+      - age:
+        - *pc

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+    "recommendations": [
+        "pinage404.nix-extension-pack",
+        "bbenoist.nix",
+        "jnoortheen.nix-ide",
+        "kamadorueda.alejandra",
+        "mkhl.direnv",
+        "dlasagno.rasi",
+        "jgclark.vscode-todo-highlight",
+        "signageos.signageos-vscode-sops",
+        "streetsidesoftware.code-spell-checker",
+        "streetsidesoftware.code-spell-checker-polish",
+        "vivaxy.vscode-conventional-commits"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,20 +1,4 @@
 {
-    "cSpell.language": "en,pl,en-US",
-    "cSpell.words": [
-        "bootloader",
-        "flatpak",
-        "Hyprland",
-        "polkit",
-        "togglable"
-    ],
-    "[nix]": {
-        "editor.insertSpaces": true,
-        "editor.tabSize": 2,
-        "editor.defaultFormatter": "kamadorueda.alejandra",
-        "editor.formatOnPaste": true,
-        "editor.formatOnSave": true,
-        "editor.formatOnType": false
-    },
     "nix.enableLanguageServer": true,
     "nix.serverPath": "nil",
     "nix.serverSettings": {
@@ -27,11 +11,28 @@
             }
         }
     },
+    "[nix]": {
+        "editor.insertSpaces": true,
+        "editor.tabSize": 2,
+        "editor.defaultFormatter": "kamadorueda.alejandra",
+        "editor.formatOnPaste": true,
+        "editor.formatOnSave": true,
+        "editor.formatOnType": false
+    },
+    "cSpell.language": "en,pl,en-US",
+    "cSpell.words": [
+        "bootloader",
+        "flatpak",
+        "Hyprland",
+        "polkit",
+        "togglable"
+    ],
     "conventionalCommits.scopes": [
         "vscode",
         "modules",
         "apps",
         "readme",
+        "todo",
         "config",
         "hardware",
         "services",
@@ -42,10 +43,16 @@
         "gnome",
         "alacritty",
         "keyring",
-        "waybar"
+        "waybar",
+        "overlays",
+        "lib",
+        "dotfiles",
+        "deps",
+        "pkgs",
+        "pc",
+        "hosts",
+        "desktop"
     ],
-    "editor.defaultFormatter": "kamadorueda.alejandra",
-    "editor.formatOnSave": true,
     "todohighlight.isEnable": true,
     "todohighlight.isCaseSensitive": true,
     "todohighlight.keywords": [
@@ -56,7 +63,7 @@
             "overviewRulerColor": "rgba(255,189,42,0.8)"
         },
         {
-            "text": "FIXME:",
+            "text": "FIXME",
             "color": "#fff",
             "backgroundColor": "#f06292",
             "overviewRulerColor": "rgba(240,98,146,0.8)"
@@ -65,6 +72,7 @@
     "todohighlight.include": [
         "**/*.txt",
         "**/*.md",
-        "**/*.nix"
+        "**/*.nix",
+        "**/*.{yml,yaml}"
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -42,6 +42,20 @@
 				"showReuseMessage": false,
 				"clear": true
 			}
+		},
+		{
+			"type": "shell",
+			"command": "nix flake check . --show-trace && echo -e '\\033[1;32m>\\033[0m Done!'",
+			"label": "nix: flake check",
+			"problemMatcher": [],
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"focus": false,
+				"panel": "dedicated",
+				"showReuseMessage": false,
+				"clear": true
+			}
 		}
 	]
 }

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   pkgs,
   inputs,
@@ -12,8 +13,14 @@
       max-jobs = 6;
       cores = 6;
       auto-optimise-store = true;
-      substituters = ["https://hyprland.cachix.org"];
-      trusted-public-keys = ["hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="];
+      substituters = [
+        "https://hyprland.cachix.org"
+        "https://cache.thalheim.io"
+      ];
+      trusted-public-keys = [
+        "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
+        "cache.thalheim.io-1:R7msbosLEZKrxk/lKxf9BTjOOH7Ax3H0Qj0/6wiHOgc="
+      ];
       experimental-features = ["nix-command" "flakes"];
     };
     package = pkgs.nixFlakes;
@@ -89,8 +96,10 @@
   };
 
   # User settings
+  sops.secrets."users/${username}/password".neededForUsers = true;
   users.users.${username} = {
     isNormalUser = true;
+    hashedPasswordFile = config.sops.secrets."users/${username}/password".path;
     description = "Krzysztof Saczuk";
     extraGroups = ["wheel"];
   };
@@ -99,8 +108,9 @@
   home-manager = {
     extraSpecialArgs = {inherit pkgs lib;};
     sharedModules = [
-      inputs.nix-colors.homeManagerModules.default
       inputs.hyprland.homeManagerModules.default
+      inputs.nix-colors.homeManagerModule
+      inputs.sops-nix.homeManagerModule
     ];
     useUserPackages = true;
     useGlobalPkgs = true;

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "age-plugin-op": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1713113173,
+        "narHash": "sha256-D20fwVqpY1aGecwIX+G6ocJHVRw2biIdm7O2Uu7u/Hw=",
+        "owner": "bromanko",
+        "repo": "age-plugin-op",
+        "rev": "da9269c5773779fffc607191c7317e88fb20c8e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bromanko",
+        "repo": "age-plugin-op",
+        "type": "github"
+      }
+    },
     "alejandra": {
       "inputs": {
         "fenix": "fenix",
@@ -502,6 +522,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1714858427,
+        "narHash": "sha256-tCxeDP4C1pWe2rYY3IIhdA40Ujz32Ufd4tcrHPSKx2M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b980b91038fc4b09067ef97bbe5ad07eecca1e76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1714635257,
@@ -582,6 +618,7 @@
     },
     "root": {
       "inputs": {
+        "age-plugin-op": "age-plugin-op",
         "alejandra": "alejandra",
         "distro-grub-themes": "distro-grub-themes",
         "home-manager": "home-manager",
@@ -593,6 +630,7 @@
         "nixd": "nixd",
         "nixpkgs": "nixpkgs_5",
         "nixpkgs-unstable": "nixpkgs-unstable",
+        "sops-nix": "sops-nix",
         "waybar": "waybar"
       }
     },
@@ -635,6 +673,28 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1711119062,
+        "narHash": "sha256-pJGGsuQpVvZwMxJfQH0DGtIEFc25MdqLiWeJfGcSJIY=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "de84e9c41eb67c121bb9bfd19361351e6b68dd84",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "ref": "yubikey-support",
+        "repo": "sops-nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,14 @@
       url = "github:Alexays/Waybar";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
+    sops-nix = {
+      url = "github:Mic92/sops-nix/yubikey-support";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    age-plugin-op = {
+      url = "github:bromanko/age-plugin-op";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     hyprland.url = "github:hyprwm/Hyprland";
     nixd.url = "github:nix-community/nixd";
     nil.url = "github:oxalica/nil";
@@ -66,6 +74,11 @@
         alejandra = flakeInputs.alejandra.packages.${system};
         hyprland-contrib = flakeInputs.hyprland-contrib.packages.${system};
         hyprpaper = flakeInputs.hyprpaper.packages.${system};
+        age-plugin-op =
+          flakeInputs.age-plugin-op.packages.${system}
+          // {
+            default = flakeInputs.age-plugin-op.packages.${system}.age-plugin-op;
+          };
         hyprland =
           flakeInputs.hyprland
           // {

--- a/hosts/pc/configuration.nix
+++ b/hosts/pc/configuration.nix
@@ -16,6 +16,11 @@ with lib.my; {
 
   home-manager.users.${username}.colorScheme = inputs.nix-colors.colorSchemes.catppuccin-mocha;
 
+  # Configure Secret Managment through sops-nix.
+  sops.age.keyFile = "/home/${username}/.config/sops/age/keys.txt";
+  sops.defaultSopsFile = ./secrets.yaml;
+  sops.defaultSopsFormat = "yaml";
+
   modules = {
     hardware = {
       grub = {

--- a/hosts/pc/secrets.yaml
+++ b/hosts/pc/secrets.yaml
@@ -1,0 +1,23 @@
+users:
+    zakuciael:
+        password: ENC[AES256_GCM,data:WjOX2hCNy9Ca8We+Phbv7bmKNJGwtTCzk2s4FK8Es7GX28S37PzfAQr+EHH9u5EEeVZNJwY3LgpdQpFwy/lco09LbmMgwjEXsA==,iv:0BoaxSJWaCZ2Ux6OsbLkyJFeg2Cju7Gxfxkz7z8yF+o=,tag:FEzVnkLlkgBpP6kmEVBvFQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1lxgv0sqxut6ekz9une8d4zzj4vkrlph58ewv5w6r6m0xxddw9dgs3j8q8r
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArcHg2bjFaemY3Y0xIQ21O
+            T3p1YmpqckFMWlFtOXlWWkpWbkxmTW14bUJzCnloa0VBWVhJZWNXWTBCcHNWQ2hs
+            eG0rNDdCY2Q2Ynp2RWViYlVLOFQvSEkKLS0tIGdjRUp0WE95VURWOWJjSXZ6dW1y
+            cXY0Q0c1c1RTeE55UmR4UXQ3WUF5REEKmWCz1p1a4XiLYEXjjQDf3AymsJarAREr
+            7sEzo5NgODyowqylz4OYUKo++kSfmrbd9EKNQRWVZnxQ2eNDZak3Gg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-05-07T14:30:52Z"
+    mac: ENC[AES256_GCM,data:sj+9jsIGbY29zw8eePcjmo/O7ACfsuEsAos7lgHLMz0wK4q1r/YNiP118TohjCT8vF5gcPIPm8HopB6QQtMXGsSLIo6x4ohbyYFHuOZC4Fh3F6nRegYUBDpZ2tX9soQCKr7kx444wj7KQSMbNaJ8hX8lDRNijKhWbspykJyVss4=,iv:vtRnA7rn3viRw17gWbz3e8Rb7WzHp0LQrTOzj6aOcRE=,tag:odLrA9hsa75dKbl6YgphJA==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -26,7 +26,8 @@ with lib.my; {
           # TODO: Remove this when nixos 24.05 releases
           "${unstable.path}/nixos/modules/programs/nh.nix"
 
-          inputs.home-manager.nixosModules.home-manager
+          inputs.home-manager.nixosModules.default
+          inputs.sops-nix.nixosModules.default
         ]
         ++ (utils.recursiveReadDir ./../modules {
           ignoredDirs = ["apps"];

--- a/modules/desktop/apps.nix
+++ b/modules/desktop/apps.nix
@@ -45,6 +45,8 @@ in {
         libsForQt5.ark
         gnome-text-editor
         gnome.eog
+        sops
+        age
       ];
     };
   };

--- a/modules/desktop/apps/_1password.nix
+++ b/modules/desktop/apps/_1password.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  inputs,
   username,
   desktop,
   ...
@@ -15,6 +16,8 @@ with lib.my; {
       polkitPolicyOwners = [username];
     };
   };
+
+  environment.systemPackages = [inputs.age-plugin-op.default];
 
   modules.desktop.wm.${desktop}.autostartPrograms = [
     "${pkgs._1password-gui}/bin/1password"

--- a/overlays/sops.nix
+++ b/overlays/sops.nix
@@ -1,0 +1,18 @@
+{lib, ...}:
+with lib; {
+  pkgs = singleton (final: prev: {
+    # TODO: Remove when https://github.com/getsops/sops/pull/1465 is merged
+    sops = final.buildGoModule {
+      inherit (prev.sops.drvAttrs) pname version subPackages ldflags;
+      inherit (prev.sops) meta;
+      src = prev.fetchFromGitHub {
+        owner = "Mic92";
+        repo = "sops";
+        rev = "a077fbf103edd823ca7be8dddd01f4f1703da40e";
+        hash = "sha256-9r9nylzD6aKtfGLOjtzGJJelUllxcC7Fzh4A9Wc2OA4=";
+      };
+
+      vendorHash = "sha256-DeeQodjVu9QtT0p+zCnVbGSAdSLLt8Y9SiOvKuaQ730=";
+    };
+  });
+}


### PR DESCRIPTION
This PR adds secrets management using the [`sops-nix`](https://github.com/Mic92/sops-nix) package. It also includes an **overlay** for the `sops` package to support `age` plugins and installs [`age-plugin-op`](https://github.com/bromanko/age-plugin-op) package when using 1Password.

Resolves: #46