### PR TITLE
chore(config): disable tmpfs

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -82,11 +82,7 @@
     initrd.availableKernelModules = ["ehci_pci" "ahci" "nvme" "xhci_pci" "usbhid" "usb_storage" "sd_mod"];
     loader.efi.canTouchEfiVariables = true;
 
-    tmp = {
-      cleanOnBoot = true;
-      useTmpfs = true;
-      tmpfsSize = "25%";
-    };
+    tmp.cleanOnBoot = true;
 
     plymouth = {
       enable = true;


### PR DESCRIPTION
This PR disables the creation of TMPFS under the`/tmp` directory. Since NixOS uses the `/tmp` directory to build the configuration, putting it into the RAM is no longer viable, due to the increasing complexity of my setup.