### PR TITLE
feat(modules): add ides

### DIFF
--- a/hosts/pc/configuration.nix
+++ b/hosts/pc/configuration.nix
@@ -105,5 +105,6 @@ with lib.my; {
       gnome-keyring.enable = true;
       wallpaper.enable = true;
     };
+    dev.ides = ["rust-rover" "webstorm" "idea-ultimate"];
   };
 }

--- a/modules/desktop/apps/gtk.nix
+++ b/modules/desktop/apps/gtk.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   pkgs,
   username,
   ...

--- a/modules/dev/ide.nix
+++ b/modules/dev/ide.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  lib,
+  pkgs,
+  unstable,
+  username,
+  ...
+}:
+with lib;
+with lib.my; let
+  cfg = config.modules.dev.ides;
+  avaiableIdes = builtins.listToAttrs (
+    builtins.map (value: {
+      name = value.pname;
+      inherit value;
+    })
+    (with pkgs.jetbrains; [
+      clion
+      datagrip
+      dataspell
+      gateway
+      goland
+      idea-community
+      idea-ultimate
+      mps
+      phpstorm
+      pycharm-community
+      pycharm-professional
+      rider
+      ruby-mine
+      unstable.jetbrains.rust-rover
+      webstorm
+    ])
+  );
+in {
+  options.modules.dev.ides = mkOption {
+    description = "A list of JetBrains IDEs names to install";
+    example = ["rust-rover" "webstorm"];
+    default = [];
+    type = with types; listOf (enum (builtins.attrNames avaiableIdes));
+  };
+
+  config = mkIf (cfg != []) {
+    home-manager.users.${username} = {
+      home.packages = builtins.map (name: avaiableIdes.${name}) cfg;
+    };
+  };
+}

--- a/overlays/whitesur-icons.nix
+++ b/overlays/whitesur-icons.nix
@@ -1,0 +1,14 @@
+{lib, ...}:
+with lib; {
+  # TODO: Remove when https://github.com/vinceliuice/WhiteSur-icon-theme/pull/293 will be upstreamed to nixpkgs
+  pkgs = singleton (final: prev: {
+    whitesur-icon-theme = prev.whitesur-icon-theme.overrideAttrs {
+      src = final.fetchFromGitHub {
+        owner = "zakuciael";
+        repo = "WhiteSur-icon-theme";
+        rev = "90a6787061bfb5a630f4295eda59d1058cf30da5";
+        hash = "sha256-S10HagxiZxbyhsmzS12X7SJOF9YqWKuhZqfjcc0mog8=";
+      };
+    };
+  });
+}


### PR DESCRIPTION
This PR adds a NixOS module to configure and install JetBrains IDEs onto the system. 

It also adds an `overlay` for the `whitesur-icon-theme` package to change the source to my fork with an icon fix for RustRover. More details can be found here vinceliuice/WhiteSur-icon-theme#293