### PR TITLE
feat(rofi): add jetbrains plugin

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -114,7 +114,7 @@
       inherit username;
       stateVersion = "23.11";
       homeDirectory = "/home/${username}";
-      packages = scripts.shellExports;
+      packages = scripts.mkShellExports config;
     };
   };
 

--- a/dotfiles/rofi/config.rasi
+++ b/dotfiles/rofi/config.rasi
@@ -21,6 +21,10 @@ configuration {
 	steal-focus: false;
 /*	dpi: -1;*/
 
+	/*---------- JetBrains settings ----------*/
+	jetbrains-custom-aliases: ["rs:RR", "web:WS", "cpp:CL"];
+    jetbrains-install-dir: "~/.local/share/JetBrains/apps/";
+
 	/*---------- Matching setting ----------*/
 	matching: "normal";
 	tokenize: true;

--- a/dotfiles/rofi/launchers/style.rasi
+++ b/dotfiles/rofi/launchers/style.rasi
@@ -10,7 +10,7 @@
 /*****----- Configuration -----*****/
 /* TODO: Add jetbrains plugin */
 configuration {
-	modi:                       "drun,ssh,filebrowser,window";
+	modi:                       "drun,jetbrains,ssh,filebrowser,window";
   show-icons:                 true;
   display-drun:               "";
   display-ssh:                "";

--- a/flake.lock
+++ b/flake.lock
@@ -102,6 +102,28 @@
         "type": "github"
       }
     },
+    "fenix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "rofi-jetbrains",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src_2"
+      },
+      "locked": {
+        "lastModified": 1715063087,
+        "narHash": "sha256-cktPkcCmJ2sR0V/FaWEuCWmKuGPbwoMltih/EfF0mXg=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "f8f16c1f2c83bea4e51e6522d988ec8bfcc8420e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -172,6 +194,24 @@
     "flake-utils_2": {
       "inputs": {
         "systems": "systems_5"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -616,6 +656,28 @@
         "type": "indirect"
       }
     },
+    "rofi-jetbrains": {
+      "inputs": {
+        "fenix": "fenix_2",
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1715391013,
+        "narHash": "sha256-ZppP8d9UNQDvOu/spJsNKl4PhMPwlGsP2WnSKQ5bmUo=",
+        "owner": "zakuciael",
+        "repo": "rofi-jetbrains",
+        "rev": "97e9571cd0466353981bb29c9b25e184461c5145",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zakuciael",
+        "repo": "rofi-jetbrains",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "age-plugin-op": "age-plugin-op",
@@ -630,6 +692,7 @@
         "nixd": "nixd",
         "nixpkgs": "nixpkgs_5",
         "nixpkgs-unstable": "nixpkgs-unstable",
+        "rofi-jetbrains": "rofi-jetbrains",
         "sops-nix": "sops-nix",
         "waybar": "waybar"
       }
@@ -642,6 +705,23 @@
         "owner": "rust-lang",
         "repo": "rust-analyzer",
         "rev": "caf23f29144b371035b864a1017dbc32573ad56d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-analyzer-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1714936835,
+        "narHash": "sha256-M+PpgfRMBfHo8Jb2ou/s3maAZbps0XnuHXQU9Hv9vL0=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "c4618fe14d39992fbbb85c2d6cad028a232c13d2",
         "type": "github"
       },
       "original": {
@@ -759,6 +839,21 @@
       }
     },
     "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_6": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,10 @@
       url = "github:bromanko/age-plugin-op";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    rofi-jetbrains = {
+      url = "github:zakuciael/rofi-jetbrains";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     hyprland.url = "github:hyprwm/Hyprland";
     nixd.url = "github:nix-community/nixd";
     nil.url = "github:oxalica/nil";
@@ -74,6 +78,7 @@
         alejandra = flakeInputs.alejandra.packages.${system};
         hyprland-contrib = flakeInputs.hyprland-contrib.packages.${system};
         hyprpaper = flakeInputs.hyprpaper.packages.${system};
+        rofi-jetbrains = flakeInputs.rofi-jetbrains.packages.${system};
         age-plugin-op =
           flakeInputs.age-plugin-op.packages.${system}
           // {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -11,7 +11,7 @@
   defs = import ./defs.nix {inherit lib;};
 
   dotfiles = mapper.mapDirToAttrs ./../dotfiles;
-  scripts = import ./scripts.nix {inherit lib pkgs unstable inputs dotfiles;};
+  scripts = import ./scripts.nix {inherit lib pkgs unstable inputs username dotfiles;};
 in {
   inherit utils mapper defs;
 

--- a/lib/overlays.nix
+++ b/lib/overlays.nix
@@ -31,6 +31,6 @@ with lib.my; let
       (builtins.map (config: attrByPath [attr] null config) overlays)
     );
 in {
-  pkgs = (getOverlaysFromAttr "pkgs") ++ privatePkgsOverlays;
+  pkgs = privatePkgsOverlays ++ (getOverlaysFromAttr "pkgs");
   unstable = getOverlaysFromAttr "unstable";
 }

--- a/lib/scripts.nix
+++ b/lib/scripts.nix
@@ -3,23 +3,25 @@
   pkgs,
   unstable,
   inputs,
+  username,
   dotfiles,
   ...
 }:
 with lib;
 with lib.my; let
-  scripts =
+  mkScripts = config:
     builtins.map
-    (file: import file {inherit lib pkgs unstable inputs dotfiles;})
+    (file: import file {inherit config lib pkgs unstable inputs username dotfiles;})
     (utils.recursiveReadDir ./../scripts {suffixes = ["nix"];});
 in {
-  shellExports =
+  mkShellExports = config:
     builtins.map
     (getAttr "package")
-    (builtins.filter (script: attrByPath ["export"] false script) scripts);
-  packages = builtins.listToAttrs (builtins.map (script: {
-      name = script.package.name;
-      value = script.package;
-    })
-    scripts);
+    (builtins.filter (script: attrByPath ["export"] false script) (mkScripts config));
+  mkScriptPackages = config:
+    builtins.listToAttrs (builtins.map (script: {
+        name = script.package.name;
+        value = script.package;
+      })
+      (mkScripts config));
 }

--- a/modules/desktop/apps/rofi.nix
+++ b/modules/desktop/apps/rofi.nix
@@ -1,14 +1,17 @@
 {
-  lib,
   pkgs,
+  inputs,
   username,
   dotfiles,
   ...
-}:
-with lib;
-with lib.my; {
+}: {
   home-manager.users.${username} = {
-    home.packages = with pkgs; [rofi-wayland];
+    programs.rofi = {
+      enable = true;
+      package = pkgs.rofi-wayland;
+      plugins = [inputs.rofi-jetbrains.default];
+    };
+
     xdg.configFile.rofi.source = dotfiles.rofi.source;
   };
 }

--- a/modules/desktop/wm/hyprland.nix
+++ b/modules/desktop/wm/hyprland.nix
@@ -8,7 +8,9 @@
   ...
 }:
 with lib;
-with lib.my;
+with lib.my; let
+  scriptPackages = scripts.mkScriptPackages config;
+in
   desktop.mkDesktopModule {
     inherit config;
 
@@ -123,8 +125,9 @@ with lib.my;
               "$mod, RIGHT, movefocus, r"
               "$mod, UP, movefocus, u"
               "$mod, DOWN, movefocus, d"
-              "SHIFT CTRL, space, exec, ${scripts.packages.rofi-launcher}/bin/rofi-launcher drun"
-              "SHIFT CTRL, Q, exec, ${scripts.packages.rofi-powermenu}/bin/rofi-powermenu"
+              "SHIFT CTRL, space, exec, ${scriptPackages.rofi-launcher}/bin/rofi-launcher drun"
+              "SHIFT CTRL, R, exec, ${scriptPackages.rofi-launcher}/bin/rofi-launcher jetbrains"
+              "SHIFT CTRL, Q, exec, ${scriptPackages.rofi-powermenu}/bin/rofi-powermenu"
             ];
 
             bindl = with pkgs; [

--- a/modules/dev/ide.nix
+++ b/modules/dev/ide.nix
@@ -32,6 +32,7 @@ with lib.my; let
       webstorm
     ])
   );
+  installedIDEs = builtins.map (name: avaiableIdes.${name}) cfg;
 in {
   options.modules.dev.ides = mkOption {
     description = "A list of JetBrains IDEs names to install";
@@ -42,7 +43,17 @@ in {
 
   config = mkIf (cfg != []) {
     home-manager.users.${username} = {
-      home.packages = builtins.map (name: avaiableIdes.${name}) cfg;
+      home = {
+        packages = installedIDEs;
+
+        file = builtins.listToAttrs (builtins.map (ide: {
+            name = ".local/share/JetBrains/apps/${ide.pname}";
+            value = {
+              source = "${ide}/${ide.pname}";
+            };
+          })
+          installedIDEs);
+      };
     };
   };
 }

--- a/scripts/rofi/launcher.nix
+++ b/scripts/rofi/launcher.nix
@@ -1,7 +1,12 @@
-{pkgs, ...}: {
+{
+  config,
+  pkgs,
+  username,
+  ...
+}: {
   package = pkgs.writeShellApplication {
     name = "rofi-launcher";
-    runtimeInputs = with pkgs; [rofi-wayland];
+    runtimeInputs = [config.home-manager.users.${username}.programs.rofi.finalPackage];
     text = ''
       rofi -theme "$HOME/.config/rofi/launchers/style.rasi" -show "$1"
     '';

--- a/scripts/rofi/powermenu.nix
+++ b/scripts/rofi/powermenu.nix
@@ -1,11 +1,20 @@
 {
+  config,
   pkgs,
   inputs,
+  username,
   ...
 }: {
   package = pkgs.writeShellApplication {
     name = "rofi-powermenu";
-    runtimeInputs = with pkgs; [rofi-wayland toybox mpc-cli alsa-utils bspwm inputs.hyprland];
+    runtimeInputs = with pkgs; [
+      config.home-manager.users.${username}.programs.rofi.finalPackage
+      toybox
+      mpc-cli
+      alsa-utils
+      bspwm
+      inputs.hyprland
+    ];
     text = ''
       # CMDs
       uptime=$(uptime -p | sed -e 's/up //g')


### PR DESCRIPTION
This PR adds support for the `rofi-jetbrains` plugin. To achieve this, I've created symlinks for the installed IDEs inside a common path from which the plugin can list recent projects.

It also modifies loading scripts so that they can access `config` as an input, this is because home-manager is responsible for overriding the `rofi-wayland` package with added plugins. So any script using `rofi` must add this specific version to the `runtimeInputs` to avoid conflicts.