### PR TITLE
refactor: migrate to `stylix`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,6 +45,121 @@
         "type": "github"
       }
     },
+    "base16": {
+      "inputs": {
+        "fromYaml": "fromYaml"
+      },
+      "locked": {
+        "lastModified": 1708890466,
+        "narHash": "sha256-LlrC09LoPi8OPYOGPXegD72v+//VapgAqhbOFS3i8sc=",
+        "owner": "SenchoPens",
+        "repo": "base16.nix",
+        "rev": "665b3c6748534eb766c777298721cece9453fdae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SenchoPens",
+        "repo": "base16.nix",
+        "type": "github"
+      }
+    },
+    "base16-alacritty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1703982197,
+        "narHash": "sha256-TNxKbwdiUXGi4Z4chT72l3mt3GSvOcz6NZsUH8bQU/k=",
+        "owner": "aarowill",
+        "repo": "base16-alacritty",
+        "rev": "c95c200b3af739708455a03b5d185d3d2d263c6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aarowill",
+        "repo": "base16-alacritty",
+        "type": "github"
+      }
+    },
+    "base16-alacritty-yaml": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1674275109,
+        "narHash": "sha256-Adwx9yP70I6mJrjjODOgZJjt4OPPe8gJu7UuBboXO4M=",
+        "owner": "aarowill",
+        "repo": "base16-alacritty",
+        "rev": "63d8ae5dfefe5db825dd4c699d0cdc2fc2c3eaf7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aarowill",
+        "repo": "base16-alacritty",
+        "rev": "63d8ae5dfefe5db825dd4c699d0cdc2fc2c3eaf7",
+        "type": "github"
+      }
+    },
+    "base16-fish": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1622559957,
+        "narHash": "sha256-PebymhVYbL8trDVVXxCvZgc0S5VxI7I1Hv4RMSquTpA=",
+        "owner": "tomyun",
+        "repo": "base16-fish",
+        "rev": "2f6dd973a9075dabccd26f1cded09508180bf5fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tomyun",
+        "repo": "base16-fish",
+        "type": "github"
+      }
+    },
+    "base16-foot": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696725948,
+        "narHash": "sha256-65bz2bUL/yzZ1c8/GQASnoiGwaF8DczlxJtzik1c0AU=",
+        "owner": "tinted-theming",
+        "repo": "base16-foot",
+        "rev": "eedbcfa30de0a4baa03e99f5e3ceb5535c2755ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-foot",
+        "type": "github"
+      }
+    },
+    "base16-helix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696727917,
+        "narHash": "sha256-FVrbPk+NtMra0jtlC5oxyNchbm8FosmvXIatkRbYy1g=",
+        "owner": "tinted-theming",
+        "repo": "base16-helix",
+        "rev": "dbe1480d99fe80f08df7970e471fac24c05f2ddb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-helix",
+        "type": "github"
+      }
+    },
+    "base16-kitty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1665001328,
+        "narHash": "sha256-aRaizTYPpuWEcvoYE9U+YRX+Wsc8+iG0guQJbvxEdJY=",
+        "owner": "kdrag0n",
+        "repo": "base16-kitty",
+        "rev": "06bb401fa9a0ffb84365905ffbb959ae5bf40805",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kdrag0n",
+        "repo": "base16-kitty",
+        "type": "github"
+      }
+    },
     "base16-schemes": {
       "flake": false,
       "locked": {
@@ -58,6 +173,38 @@
       "original": {
         "owner": "tinted-theming",
         "repo": "base16-schemes",
+        "type": "github"
+      }
+    },
+    "base16-tmux": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696725902,
+        "narHash": "sha256-wDPg5elZPcQpu7Df0lI5O8Jv4A3T6jUQIVg63KDU+3Q=",
+        "owner": "tinted-theming",
+        "repo": "base16-tmux",
+        "rev": "c02050bebb60dbb20cb433cd4d8ce668ecc11ba7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-tmux",
+        "type": "github"
+      }
+    },
+    "base16-vim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1663659192,
+        "narHash": "sha256-uJvaYYDMXvoo0fhBZUhN8WBXeJ87SRgof6GEK2efFT0=",
+        "owner": "chriskempson",
+        "repo": "base16-vim",
+        "rev": "3be3cd82cd31acfcab9a41bad853d9c68d30478d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "chriskempson",
+        "repo": "base16-vim",
         "type": "github"
       }
     },
@@ -105,6 +252,22 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -136,6 +299,22 @@
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "fromYaml": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1689549921,
+        "narHash": "sha256-iX0pk/uB019TdBGlaJEWvBCfydT6sRq+eDcGPifVsCM=",
+        "owner": "SenchoPens",
+        "repo": "fromYaml",
+        "rev": "11fbbbfb32e3289d3c631e0134a23854e7865c84",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SenchoPens",
+        "repo": "fromYaml",
         "type": "github"
       }
     },
@@ -311,7 +490,8 @@
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nostale-dev-env": "nostale-dev-env",
         "rofi-jetbrains": "rofi-jetbrains",
-        "sops-nix": "sops-nix"
+        "sops-nix": "sops-nix",
+        "stylix": "stylix"
       }
     },
     "rust-analyzer-src": {
@@ -377,6 +557,40 @@
         "owner": "Mic92",
         "ref": "yubikey-support",
         "repo": "sops-nix",
+        "type": "github"
+      }
+    },
+    "stylix": {
+      "inputs": {
+        "base16": "base16",
+        "base16-alacritty": "base16-alacritty",
+        "base16-alacritty-yaml": "base16-alacritty-yaml",
+        "base16-fish": "base16-fish",
+        "base16-foot": "base16-foot",
+        "base16-helix": "base16-helix",
+        "base16-kitty": "base16-kitty",
+        "base16-tmux": "base16-tmux",
+        "base16-vim": "base16-vim",
+        "flake-compat": "flake-compat",
+        "home-manager": [
+          "home-manager"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1715514886,
+        "narHash": "sha256-KZkl9aTYcuCM4okpeCIaJCuS4WkE+mVG3EMyNaidyQI=",
+        "owner": "danth",
+        "repo": "stylix",
+        "rev": "f1c49b9b4d371e03273465a54dd434ac8611ee90",
+        "type": "github"
+      },
+      "original": {
+        "owner": "danth",
+        "ref": "release-23.11",
+        "repo": "stylix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };
+    stylix = {
+      url = "github:danth/stylix/release-23.11";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.home-manager.follows = "home-manager";
+    };
     nil = {
       url = "github:oxalica/nil";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
@@ -86,8 +91,12 @@
           // {packages = flakeInputs.nostale-dev-env.packages.${system};};
         age-plugin-op =
           flakeInputs.age-plugin-op.packages.${system}
+          // {default = flakeInputs.age-plugin-op.packages.${system}.age-plugin-op;};
+        stylix =
+          flakeInputs.stylix
           // {
-            default = flakeInputs.age-plugin-op.packages.${system}.age-plugin-op;
+            packages = flakeInputs.stylix.packages.${system};
+            nixosModules = flakeInputs.stylix.nixosModules // {default = flakeInputs.stylix.nixosModules.stylix;};
           };
       };
 
@@ -104,5 +113,7 @@
       mappedHosts = builtins.mapAttrs (n: v: mkHost {name = n;}) hosts;
     in
       mappedHosts;
+
+    inherit pkgs lib inputs;
   };
 }

--- a/hosts/pc/configuration.nix
+++ b/hosts/pc/configuration.nix
@@ -1,11 +1,14 @@
 {
+  config,
   lib,
   inputs,
   username,
   dotfiles,
   ...
 }:
-with lib.my; {
+with lib.my; let
+  colorScheme = inputs.nix-colors.colorSchemes.catppuccin-mocha;
+in {
   imports = [./hardware.nix ./networking.nix];
 
   environment = {
@@ -14,7 +17,15 @@ with lib.my; {
     };
   };
 
-  home-manager.users.${username}.colorScheme = inputs.nix-colors.colorSchemes.catppuccin-mocha;
+  home-manager.users.${username} = {
+    inherit colorScheme;
+    stylix.base16Scheme = colorScheme;
+    stylix.autoEnable = false;
+  };
+
+  stylix.image = ""; # Workaround for Stylix requirement for this to be set.
+  stylix.base16Scheme = colorScheme;
+  stylix.autoEnable = false;
 
   # Configure Secret Managment through sops-nix.
   sops.age.keyFile = "/home/${username}/.config/sops/age/keys.txt";

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -28,6 +28,7 @@ with lib.my; {
 
           inputs.home-manager.nixosModules.default
           inputs.sops-nix.nixosModules.default
+          inputs.stylix.nixosModules.default
         ]
         ++ (utils.recursiveReadDir ./../modules {
           ignoredDirs = ["apps"];

--- a/modules/desktop/apps/alacritty.nix
+++ b/modules/desktop/apps/alacritty.nix
@@ -1,49 +1,19 @@
 {
-  lib,
   pkgs,
   username,
-  colorScheme,
   ...
-}:
-with lib; {
-  home-manager.users.${username}.programs.alacritty = {
-    enable = true;
-    settings = {
-      general = {
-        shell = "${pkgs.fish}/bin/fish";
-        "live_config_reload" = false;
-      };
-      env.TERM = "xterm-256color";
+}: {
+  home-manager.users.${username} = {
+    stylix.targets.alacritty.enable = true;
 
-      colors = with colorScheme.palette; {
-        bright = {
-          black = "0x${base00}";
-          blue = "0x${base0D}";
-          cyan = "0x${base0C}";
-          green = "0x${base0B}";
-          magenta = "0x${base0E}";
-          red = "0x${base08}";
-          white = "0x${base06}";
-          yellow = "0x${base09}";
+    programs.alacritty = {
+      enable = true;
+      settings = {
+        general = {
+          shell = "${pkgs.fish}/bin/fish";
+          "live_config_reload" = false;
         };
-        cursor = {
-          cursor = "0x${base06}";
-          text = "0x${base06}";
-        };
-        normal = {
-          black = "0x${base00}";
-          blue = "0x${base0D}";
-          cyan = "0x${base0C}";
-          green = "0x${base0B}";
-          magenta = "0x${base0E}";
-          red = "0x${base08}";
-          white = "0x${base06}";
-          yellow = "0x${base0A}";
-        };
-        primary = {
-          background = "0x${base00}";
-          foreground = "0x${base06}";
-        };
+        env.TERM = "xterm-256color";
       };
     };
   };

--- a/modules/shell/fish.nix
+++ b/modules/shell/fish.nix
@@ -26,6 +26,8 @@ in {
     environment.shells = mkIf cfg.default (with pkgs; [fish]);
 
     home-manager.users.${username} = {
+      stylix.targets.fish.enable = true;
+
       programs = {
         direnv = {
           enable = cfg.direnv.enable;

--- a/modules/shell/tmux.nix
+++ b/modules/shell/tmux.nix
@@ -14,6 +14,8 @@ in {
 
   config = mkIf cfg.enable {
     home-manager.users.${username} = {
+      stylix.targets.tmux.enable = true;
+
       programs.tmux = {
         enable = true;
         mouse = true;


### PR DESCRIPTION
This PR migrates some of the ricing to the `stylix` package, leaving the custom ricing untouched.