### PR TITLE
refactor(config): migrate to `catppuccin/nix`

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -115,6 +115,7 @@
     sharedModules = [
       inputs.nix-colors.homeManagerModule
       inputs.sops-nix.homeManagerModule
+      inputs.catppuccin.homeManagerModule
     ];
     useUserPackages = true;
     useGlobalPkgs = true;

--- a/flake.lock
+++ b/flake.lock
@@ -208,6 +208,21 @@
         "type": "github"
       }
     },
+    "catppuccin": {
+      "locked": {
+        "lastModified": 1716337435,
+        "narHash": "sha256-eZqH1vLI9eKL/N5toXxOrQO80G0y4pWZrYCp472YBVQ=",
+        "owner": "catppuccin",
+        "repo": "nix",
+        "rev": "fea5242c0eacc5efa81be0e36206a62e889dbd82",
+        "type": "github"
+      },
+      "original": {
+        "owner": "catppuccin",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "distro-grub-themes": {
       "inputs": {
         "flake-utils": [
@@ -480,6 +495,7 @@
       "inputs": {
         "age-plugin-op": "age-plugin-op",
         "alejandra": "alejandra",
+        "catppuccin": "catppuccin",
         "distro-grub-themes": "distro-grub-themes",
         "fenix": "fenix",
         "flake-utils": "flake-utils",

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,7 @@
     nixpkgs-unstable.url = "nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     nix-colors.url = "github:misterio77/nix-colors";
+    catppuccin.url = "github:catppuccin/nix";
     fenix = {
       url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -98,6 +99,16 @@
             packages = flakeInputs.stylix.packages.${system};
             nixosModules = flakeInputs.stylix.nixosModules // {default = flakeInputs.stylix.nixosModules.stylix;};
           };
+        catppuccin =
+          flakeInputs.catppuccin
+          // {
+            homeManagerModule = flakeInputs.catppuccin.homeManagerModules.catppuccin;
+            nixosModules =
+              flakeInputs.catppuccin.nixosModules
+              // {
+                default = flakeInputs.catppuccin.nixosModules.catppuccin;
+              };
+          };
       };
 
     lib = nixpkgs.lib.extend (self: super: {
@@ -115,5 +126,7 @@
       mappedHosts;
 
     devShells.${system}.default = pkgs.callPackage ./shell.nix {};
+
+    inherit pkgs unstable inputs lib;
   };
 }

--- a/hosts/pc/configuration.nix
+++ b/hosts/pc/configuration.nix
@@ -18,22 +18,23 @@ in {
     };
   };
 
+  # Color theme configuration
+  catppuccin.flavor = "mocha";
   home-manager.users.${username} = {
     inherit colorScheme;
     stylix.base16Scheme = colorScheme.palette;
     stylix.autoEnable = false;
   };
 
-  stylix.image = ""; # Workaround for Stylix requirement for this to be set.
   stylix.base16Scheme = colorScheme.palette;
   stylix.autoEnable = false;
 
-  # Configure Secret Managment through sops-nix.
+  # Secret management configuration
   sops.age.keyFile = "/home/${username}/.config/sops/age/keys.txt";
   sops.defaultSopsFile = ./secrets.yaml;
   sops.defaultSopsFormat = "yaml";
 
-  # Configure ZSA keyboards
+  # ZSA keyboard configuration
   hardware.keyboard.zsa.enable = true;
   environment.systemPackages = with pkgs; [wally-cli];
 

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -29,6 +29,7 @@ with lib.my; {
           inputs.home-manager.nixosModules.default
           inputs.sops-nix.nixosModules.default
           inputs.stylix.nixosModules.default
+          inputs.catppuccin.nixosModules.default
         ]
         ++ (utils.recursiveReadDir ./../modules {
           ignoredDirs = ["apps"];

--- a/modules/desktop/apps.nix
+++ b/modules/desktop/apps.nix
@@ -44,7 +44,6 @@ in {
         libsForQt5.ark
         gnome-text-editor
         gnome.eog
-        btop
       ];
     };
   };

--- a/modules/desktop/apps/alacritty.nix
+++ b/modules/desktop/apps/alacritty.nix
@@ -4,10 +4,11 @@
   ...
 }: {
   home-manager.users.${username} = {
-    stylix.targets.alacritty.enable = true;
+    # stylix.targets.alacritty.enable = true;
 
     programs.alacritty = {
       enable = true;
+      catppuccin.enable = true;
       settings = {
         general = {
           shell = "${pkgs.fish}/bin/fish";

--- a/modules/desktop/apps/btop.nix
+++ b/modules/desktop/apps/btop.nix
@@ -1,0 +1,14 @@
+{
+  config,
+  lib,
+  pkgs,
+  username,
+  ...
+}:
+with lib;
+with lib.my; {
+  home-manager.users.${username} = {
+    home.packages = with pkgs; [btop];
+    programs.btop.catppuccin.enable = true;
+  };
+}

--- a/modules/desktop/wm/hyprland.nix
+++ b/modules/desktop/wm/hyprland.nix
@@ -25,6 +25,7 @@ in
       "qt"
       "grimblast"
       "steam"
+      "btop"
     ];
 
     extraConfig = {

--- a/modules/shell/fish.nix
+++ b/modules/shell/fish.nix
@@ -26,8 +26,6 @@ in {
     environment.shells = mkIf cfg.default (with pkgs; [fish]);
 
     home-manager.users.${username} = {
-      stylix.targets.fish.enable = true;
-
       programs = {
         direnv = {
           enable = cfg.direnv.enable;
@@ -45,6 +43,7 @@ in {
 
         fish = {
           enable = true;
+          catppuccin.enable = true;
           shellAliases = {
             re = "nh os switch -H ${hostname} && echo -e '\\033[32m>\\033[0m Done!'";
             nfu = "nix flake update";

--- a/modules/shell/tmux.nix
+++ b/modules/shell/tmux.nix
@@ -14,13 +14,12 @@ in {
 
   config = mkIf cfg.enable {
     home-manager.users.${username} = {
-      stylix.targets.tmux.enable = true;
-
       programs.tmux = {
         enable = true;
+        catppuccin.enable = true;
         mouse = true;
         newSession = false;
-        plugins = with pkgs.tmuxPlugins; [sensible yank catppuccin];
+        plugins = with pkgs.tmuxPlugins; [sensible yank];
         shell = "${pkgs.fish}/bin/fish";
         prefix = "C-Space";
         baseIndex = 1;


### PR DESCRIPTION
This PR migrates color theme configuration to `catppuccin/nix` resolving the #73 issue.
Note that this PR leaves the `nix-colors` and `stylix` configurations intact and only disables the program-specific ones.